### PR TITLE
Fixes error when backspace from first input box.

### DIFF
--- a/src/PinInput.jsx
+++ b/src/PinInput.jsx
@@ -58,7 +58,9 @@ class PinInput extends Component {
   }
 
   onBackspace(index) {
-    this.elements[index - 1].focus();
+    if (index > 0) {
+      this.elements[index - 1].focus();
+    }
   }
 
   render() {


### PR DESCRIPTION
Error I was getting:

```
PinInput.jsx:62 Uncaught TypeError: Cannot read property 'focus' of undefined
    at PinInput.onBackspace (PinInput.jsx:62)
    at Object.onBackspace (PinInput.jsx:74)
    at PinItem.onKeyDown (PinItem.jsx:18)
    at Object.ReactErrorUtils.invokeGuardedCallback (ReactErrorUtils.js:69)
    at executeDispatch (EventPluginUtils.js:85)
    at Object.executeDispatchesInOrder (EventPluginUtils.js:108)
    at executeDispatchesAndRelease (EventPluginHub.js:43)
    at executeDispatchesAndReleaseTopLevel (EventPluginHub.js:54)
    at Array.forEach (<anonymous>)
    at forEachAccumulated (forEachAccumulated.js:24)
```