### PR TITLE
inputMode prop

### DIFF
--- a/src/PinItem.jsx
+++ b/src/PinItem.jsx
@@ -30,7 +30,7 @@ class PinItem extends Component {
     this.onChange = this.onChange.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onFocus = this.onFocus.bind(this);
-    this.onBlur = this.onBlur.bind(this);    
+    this.onBlur = this.onBlur.bind(this);
   }
 
   onKeyDown(e) {
@@ -89,7 +89,7 @@ class PinItem extends Component {
   render() {
     const { focus, value } = this.state;
     const { type, inputMode, inputStyle, inputFocusStyle } = this.props;
-    const inputType = this.props.type === 'numeric' ? 'tel' : (this.props.type || 'text');
+    const inputType = type === 'numeric' ? 'tel' : (type || 'text');
     return (<input
       disabled={ this.props.disabled ? "disabled": undefined }
       className='pincode-input-text'
@@ -100,6 +100,7 @@ class PinItem extends Component {
       maxLength='1'
       autoComplete='off'
       type={ this.props.secret ? 'password' : inputType }
+      inputMode={ inputMode || 'text'}
       pattern={ this.props.type === 'numeric' ? '[0-9]*' : '[A-Z0-9]*' }
       ref={ n => (this.input = n) }
       onFocus={ this.onFocus }


### PR DESCRIPTION
First thank you for this component.
I am trying to achieve following requirements and this pull request will help me to come one step closer to it.

1. Accept only numbers
2. Numbers must be hidden (like passwords)
3. Open keypad on mobile devices

[This answer](https://stackoverflow.com/a/31619311/2179502)  is helpful for 1 and 3.
[This answer](https://stackoverflow.com/a/8334379/2179502) is helpful for number 2, but as author mentioned it only works in WebKit based browsers.

Back to this pull request, it seems ability to set `inputMode` will be useful feature to support different solutions.  