### PR TITLE
[README] Added import to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ npm install react-pin-input --save
 The component takes in the length of the PIN and two callback to notifiy change and completion. The ```index``` is the input which is currently in focus.
 
 ```javascript
+import PinInput from 'react-pin-input';
+
 <PinInput 
   length={4} 
   initialValue=""


### PR DESCRIPTION
Changes proposed in this PR:
* Adds `import PinInput from 'react-pin-input';` to usage example.

I know the package is imported as any other import, but it's always nice to have it ready to copy-paste.