### PR TITLE
Add inputMode in ts interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The component takes in the length of the PIN and two callback to notifiy change 
   secret 
   onChange={(value, index) => {}} 
   type="numeric" 
+  inputMode="number"
   style={{padding: '10px'}}  
   inputStyle={{borderColor: 'red'}}
   inputFocusStyle={{borderColor: 'blue'}}

--- a/typings/react-pin-input.d.ts
+++ b/typings/react-pin-input.d.ts
@@ -7,6 +7,7 @@ declare module 'react-pin-input' {
         length: number;
         initialValue?: number|string;
         type?: InputType;
+        inputMode?: string;
         secret?: boolean;
         focus?: boolean;
         onChange?: (value: string, index: number) => void;


### PR DESCRIPTION
This PR comes as an addition to [PR 156](https://github.com/arunghosh/react-pin-input/pull/156). I added `inputMode` in the ts interface so that this feature can be used with normal typescript code, without adding annotations to circumvent compilation errors.