### PR TITLE
Add disabled prop to PinInputProps

### DIFF
--- a/typings/react-pin-input.d.ts
+++ b/typings/react-pin-input.d.ts
@@ -9,6 +9,7 @@ declare module 'react-pin-input' {
         type?: InputType;
         inputMode?: string;
         secret?: boolean;
+        disabled?: boolean;
         focus?: boolean;
         onChange?: (value: string, index: number) => void;
         onComplete?: (value: string, index: number) => void;


### PR DESCRIPTION
The disabled property seems to have been accidentally left out of the typescript interface. Adding it in this PR.