### PR TITLE
feat: adds optional secret delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-pin-input",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "React component for PIN like input",
   "main": "dist/bundle.js",
   "scripts": {

--- a/src/PinInput.jsx
+++ b/src/PinInput.jsx
@@ -7,7 +7,7 @@ import PinItem from './PinItem';
 class PinInput extends Component {
   constructor(props) {
     super(props);
-
+  
     this.values = Array(props.length)
       .fill('')
       .map((x, i) => props.initialValue.toString()[i] || '');
@@ -100,6 +100,7 @@ class PinInput extends Component {
             regexCriteria={this.props.regexCriteria}
             ariaLabel={this.props.ariaLabel}
             placeholder={this.props.placeholder}
+            secretDelay={this.props.secretDelay}
           />
         ))}
       </div>

--- a/src/PinItem.jsx
+++ b/src/PinItem.jsx
@@ -24,6 +24,7 @@ class PinItem extends Component {
     super(props);
     this.state = {
       value: this.validate(props.initialValue),
+      showSecret: this.props.secret,
       focus: false,
     };
     this.onChange = this.onChange.bind(this);
@@ -31,6 +32,13 @@ class PinItem extends Component {
     this.onFocus = this.onFocus.bind(this);
     this.onBlur = this.onBlur.bind(this);
     this.onPaste = this.onPaste.bind(this);
+    this.secretTimeout = null;
+    this.inputTimeout = null;
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.secretTimeout);
+    clearTimeout(this.inputTimeout)
   }
 
   onKeyDown(e) {
@@ -45,6 +53,15 @@ class PinItem extends Component {
     });
   }
 
+  setSecretDelayed(value){
+    this.setState({ showSecret: false });
+    this.secretTimeout =  setTimeout(()=>{
+        this.setState({
+          showSecret: value ? true : false,
+        });
+      } ,this.props.secretDelay);
+  }
+
   update(updatedValue, isPasting = false) {
     const value = this.validate(updatedValue);
     if (this.state.value === value && !isPasting) return;
@@ -54,10 +71,10 @@ class PinItem extends Component {
         value,
       });
 
-      setTimeout(() => {
+     this.inputTimeout = setTimeout(() => {
         this.props.onChange(value, isPasting);
       }, 0);
-    }
+    } 
   }
 
   onChange(e) {
@@ -89,6 +106,8 @@ class PinItem extends Component {
   }
 
   validate(value) {
+    if(this.props.secretDelay) this.setSecretDelayed(value)
+
     if (this.props.validate) {
       return this.props.validate(value);
     }
@@ -120,7 +139,7 @@ class PinItem extends Component {
         aria-label={this.props.ariaLabel ? this.props.ariaLabel : value}
         maxLength='1'
         autoComplete='off'
-        type={this.props.secret ? 'password' : inputType}
+        type={this.state.showSecret ? 'password' : inputType}
         inputMode={inputMode || 'text'}
         pattern={this.props.type === 'numeric' ? '[0-9]*' : '^[a-zA-Z0-9]+$'}
         ref={n => (this.input = n)}
@@ -145,6 +164,7 @@ PinItem.propTypes = {
   onBackspace: PropTypes.func.isRequired,
   onPaste: PropTypes.func,
   secret: PropTypes.bool,
+  secretDelay: PropTypes.number,
   disabled: PropTypes.bool,
   type: PropTypes.string,
   inputMode: PropTypes.string,


### PR DESCRIPTION
## Description
The feature enables optional secret delay prop.

## Why
Improves user feedback when entering the PIN and prevent wrong input.

## DEMO
Steps:
- Secret + 100ms Secret delay with initalValue
- Secret + 100ms Secret delay without initalValue
- Secret without Secret delay prop.
- No Secret, no Secret delay prop.

https://user-images.githubusercontent.com/6036910/220919401-944437e5-24de-499f-8905-0a94be79145a.mov

